### PR TITLE
Clarify guidance on whitespace in ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,18 +357,21 @@ xy = foo(x, y=3)
     No:  if x == 4 @show(x , y) ; x , y = y , x end
     ```
 
-- Avoid extraneous whitespace when using ranges unless additional operators are used:
+- Avoid whitespace around `:` in ranges. Use brackets to clarify expressions on either side.
 
     ```julia
-    Yes: ham[1:9], ham[1:3:9], ham[1:3:end]
-    No:  ham[1: 9], ham[1 : 3: 9]
-    ```
+    # Yes:
+    ham[1:9]
+    ham[9:-3:0]
+    ham[1:step:end]
+    ham[lower:upper-1]  # or ham[lower:upper - 1]
+    ham[lower:(upper + offset)]
+    ham[(lower + offset):(upper + offset)]
 
-    ```julia
-    Yes: ham[lower:upper], ham[lower:step:upper]
-    Yes: ham[lower + offset : upper + offset]
-    Yes: ham[(lower + offset):(upper + offset)]
-    No:  ham[lower + offset:upper + offset]
+    # No:
+    ham[1: 9]
+    ham[9 : -3: 1]
+    ham[lower : upper - 1]
     ```
 
 - Avoid using more than one space around an assignment (or other) operator to align it with another:

--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ xy = foo(x, y=3)
     ham[1: 9]
     ham[9 : -3: 1]
     ham[lower : upper - 1]
+    ham[lower + offset:upper + offset]  # Avoid as it is easy to read as `ham[lower + (offset:upper) + offset]`
     ```
 
 - Avoid using more than one space around an assignment (or other) operator to align it with another:

--- a/README.md
+++ b/README.md
@@ -364,7 +364,8 @@ xy = foo(x, y=3)
     ham[1:9]
     ham[9:-3:0]
     ham[1:step:end]
-    ham[lower:upper-1]  # or ham[lower:upper - 1]
+    ham[lower:upper-1]
+    ham[lower:upper - 1]
     ham[lower:(upper + offset)]
     ham[(lower + offset):(upper + offset)]
 


### PR DESCRIPTION
prompted by #20 

I think this is consistent with the style is used in practice, and is mostly a clarification.

There is one guidance change:
before `ham[lower:upper - 1]` was under `no` (the example was `ham[lower + offset:upper + offset]`, but now we say that `ham[lower:upper - 1]` is okay.