### PR TITLE
Clarify docs style in Markdown files is different

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,7 +880,7 @@ Avoid aligning the text to the `:`.
 
 For additional details on documenting in Julia see the [official documentation](http://docs.julialang.org/en/latest/manual/documentation/).
 
-For documentation written in Markdown files such as `README.md` or `docs/src.index.md` use exactly one sentence per line.
+For documentation written in Markdown files such as `README.md` or `docs/src/index.md` use exactly one sentence per line.
 
 ## Test Formatting
 

--- a/README.md
+++ b/README.md
@@ -880,6 +880,8 @@ Avoid aligning the text to the `:`.
 
 For additional details on documenting in Julia see the [official documentation](http://docs.julialang.org/en/latest/manual/documentation/).
 
+For documentation written in Markdown files such as `README.md` or `docs/src.index.md` use exactly one sentence per line.
+
 ## Test Formatting
 
 ### Testsets


### PR DESCRIPTION
Prompted by #20 

While this is not a Markdown style guide, I think this one-liner is justified: we want to be clear the docstring line length (wrapping at 92 Chars) is for `.jl` files; and for markdown docs files (inlucding this guide itself) we use one sentence per line. 