### PR TITLE
Delete reference to if you do want import

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,23 +141,6 @@ hello(x::Monster) = "Aargh! It's a Monster!"
 isreal(x::Ghost) = false
 ```
 
-If you do require the use of `import` then create separate groupings for `import` and `using` statements divided by a blank line:
-
-```julia
-# Yes:
-import A: a
-import C
-
-using B
-using D: d
-
-# No:
-import A: a
-using B
-import C
-using D: d
-```
-
 ### Global Variables
 
 Global variables should be avoided whenever possible. When required, global variables should be `const`s and have an all uppercase name seperated with underscores (e.g. `MY_CONSTANT`).


### PR DESCRIPTION
It is kinda silly to have rules for how to do `import` when just above it says: _"never do import"_.
Now sometimes one does have good reasons to do import, and thus violate the aboe rule,
but at that point you're kinda on your own,
and should act inline with your reasoning behind ignoring that rule in the first place.
