### PR TITLE
Add example of keyword only function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,10 @@ This avoids mistakes in ambiguous cases (such as splatting a `Dict`).
 ```julia
 # Yes:
 xy = foo(x; y=3)
+ab = foo(; a=1, b=2)
+
+# Ok:
+ab = foo(a=1, b=2)
 
 # No:
 xy = foo(x, y=3)


### PR DESCRIPTION
Prompted by #20 

Before we were a little ambiguous on `f(; a=1, b=1)` versus `f(a=1, b=2)`.

Now we recommend as okay `f(a=1, b=2)` 

~Should we also explicity recommend against `f(; a=1, b=1)` (by adding the example under "no")?~

___

Edit: changed to saying either is okay
