### PR TITLE
Added recommended VS Code settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,7 +947,7 @@ Then navigate to: `Preferences > Settings - More > Syntax Specific - User`
 ### VS Code Settings
 
 If you are a user of VS Code we recommend that you have the following options in your Julia syntax specific settings.
-To modify these settings open your VS Code Settings with `CRTL + S`.
+To modify these settings open your VS Code Settings with `CRTL + ,`.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -944,6 +944,25 @@ Then navigate to: `Preferences > Settings - More > Syntax Specific - User`
 }
 ```
 
+### VS Code Settings
+
+If you are a user of VS Code we recommend that you have the following options in your Julia syntax specific settings.
+To modify these settings open your VS Code Settings with `CRTL + S`.
+
+```json
+{
+    "[julia]": {
+        "editor.detectIndentation": false,
+        "editor.insertSpaces": true,
+        "editor.tabSize": 4,
+        "files.insertFinalNewline": true,
+        "files.trimFinalNewlines": true,
+        "files.trimTrailingWhitespace": true,
+        "editor.rulers": [92],
+    },
+}
+```
+
 ### Vim Settings
 
 If you are a user of Vim we recommend that you add to your `.vim/vimrc` file:


### PR DESCRIPTION
Add Julia specific VSCode settings. These reflect the settings for the other editors.
Trim trailing newlines should really be a default setting for the other editors as well.

It would be also useful to add the following settings, but thats not in the style guide at the moment.
```json
{
        "editor.wordWrap": "bounded",
        "editor.wordWrapColumn": 92,
}
```

Fix #28 