### PR TITLE
Add details on module importing order

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,15 @@ using A
 ```
 
 Imports which explicitly declare what to bring into scope should be grouped into: modules, constants, types, macros, and functions.
-These groupings should be specified in that order and each group's contents should be sorted alphabetically.
+These groupings should be specified in that order and each group's contents should be sorted alphabetically, typically with modules on a separate line.
 As pseudo-code:
+
+```julia
+using Example: $(sort(modules)...)
+using Example: $(sort(constants)...), $(sort(types)...), $(sort(macros)...), $(sort(functions)...)
+```
+
+If you are only explicitly importing a few items you can alternatively use the following one-line form:
 
 ```julia
 using Example: $(sort(modules)...), $(sort(constants)...), $(sort(types)...), $(sort(macros)...), $(sort(functions)...)

--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ using B
 using A
 ```
 
-Imports which explicitly declare what to bring into scope should be grouped into: constants, types, macros, and functions.
+Imports which explicitly declare what to bring into scope should be grouped into: modules, constants, types, macros, and functions.
 These groupings should be specified in that order and each group's contents should be sorted alphabetically.
 As pseudo-code:
 
 ```julia
-using Example: $(sort(constants)...), $(sort(types)...), $(sort(macros)...), $(sort(functions)...)
+using Example: $(sort(modules)...), $(sort(constants)...), $(sort(types)...), $(sort(macros)...), $(sort(functions)...)
 ```
 
 In some scenarios there may be alternate ordering within a group which makes more logical sense.


### PR DESCRIPTION
I think import modules should precede constants. I'll note when constants are missing it my be difficult to discern modules from types as they use the same casing convention. We may want to encourage module imports are done separately from the rest e.g.:
```
using Example: $(sort(modules)...)
using Example: $(sort(constants)...), $(sort(types)...), $(sort(macros)...), $(sort(functions)...)
```
I do think we need to provide a one-line form though.