### PR TITLE
use in in loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ When convention guidelines conflict this guide takes precedence (known conflicts
     - [NamedTuples](#namedtuples)
     - [Numbers](#numbers)
     - [Ternary Operator](#ternary-operator)
-    - [For loops](#for-loop)
+    - [For loops](#for-loops)
     - [Type annotation](#type-annotation)
     - [Package version specifications](#package-version-specifications)
     - [Comments](#comments)
@@ -762,7 +762,7 @@ else
 end
 ```
 
-### For lops
+### For loops
 For loops should always use `in`, never `=` or `∈`.
 This also applies to list and generator comprehensions
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ When convention guidelines conflict this guide takes precedence (known conflicts
     - [NamedTuples](#namedtuples)
     - [Numbers](#numbers)
     - [Ternary Operator](#ternary-operator)
+    - [For loops](#for-loop)
     - [Type annotation](#type-annotation)
     - [Package version specifications](#package-version-specifications)
     - [Comments](#comments)
@@ -760,6 +761,27 @@ else
     baz
 end
 ```
+
+### For lops
+For loops should always use `in`, never `=` or `∈`.
+This also applies to list and generator comprehensions
+
+```julia
+# Yes
+for i in 1:10
+    #...
+end
+
+[foo(x) for x in xs]
+
+# No:
+for i = 1:10
+    #...
+end
+
+[foo(x) for x ∈ xs]
+```
+
 
 ### Type annotation
 


### PR DESCRIPTION
I don't believe we were allowing this.
I think it is just not forbidden because noone has ever done it.
Since `=` is so gross,
and `∈` is just a bit too annoying to type.