### PR TITLE
Fix triple-quote guidance to be about style of semantically equal code

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,21 @@ xy = foo(x, y=3)
           ```
     ```
 
+- Assignments using triple-quotes or triple-backticks should have the opening quotes on the same line assignment operator.
+
+    ```julia
+    # Yes:
+    str2 = """
+           hello
+       world!
+       """
+
+    # No:
+    str2 =
+       """
+           hello
+       world!
+       """
     ```
 
 - Group similar one line statements together.

--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ xy = foo(x, y=3)
     ```
 
 - Triple-quotes and triple-backticks written over multiple lines should be indented.
-  Since triple-quotes use the indentation of the lowest indented line excluding the opening quotes, the least indented line in the string should be aligned with the closing quotes (i.e. also indented once).
+  As triple-quotes use the indentation of the lowest indented line (excluding the opening quotes) the least indented line in the string or ending quotes should be indented once.
   Triple-backticks should also follow this style even though the indentation does not matter for them.
 
     ```julia

--- a/README.md
+++ b/README.md
@@ -601,7 +601,7 @@ xy = foo(x, y=3)
     arr = [1, 2, 3,]
     ```
 
-- Triple-quotes and triple-backticks written over multiple lines should have closing quotes indented once.
+- Triple-quotes and triple-backticks written over multiple lines should be indented.
   Since triple-quotes use the indentation of the lowest indented line excluding the opening quotes, the least indented line in the string should be aligned with the closing quotes (i.e. also indented once).
   Triple-backticks should also follow this style even though the indentation does not matter for them.
 

--- a/README.md
+++ b/README.md
@@ -601,8 +601,8 @@ xy = foo(x, y=3)
     arr = [1, 2, 3,]
     ```
 
-- Triple-quotes use the indentation of the lowest indented line (excluding the opening triple-quote).
-  This means the closing triple-quote should be aligned to the least indented line in the string.
+- Triple-quotes and triple-backticks written over multiple lines should have closing quotes indented once.
+  Since triple-quotes use the indentation of the lowest indented line excluding the opening quotes, the least indented line in the string should be aligned with the closing quotes (i.e. also indented once).
   Triple-backticks should also follow this style even though the indentation does not matter for them.
 
     ```julia
@@ -611,20 +611,24 @@ xy = foo(x, y=3)
         hello
         world!
         """
-    str = """
-            hello
-        world!
-        """
     cmd = ```
         program
             --flag value
             parameter
         ```
+
     # No:
     str = """
-        hello
-        world!
+    hello
+    world!
     """
+    cmd = ```
+          program
+              --flag value
+              parameter
+          ```
+    ```
+
     ```
 
 - Group similar one line statements together.

--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ xy = foo(x, y=3)
           ```
     ```
 
-- Assignments using triple-quotes or triple-backticks should have the opening quotes on the same line assignment operator.
+- Assignments using triple-quotes or triple-backticks should have the opening quotes on the same line as the assignment operator.
 
     ```julia
     # Yes:


### PR DESCRIPTION
- Fixes #60 
  - This guidance was previously unclear -- it seemed to be about how triple-quoted strings work, and the examples didn't contain like-for-like code
- This documents the convention for indenting the closing quotes, and (like with expanded arrays or tuples) starting on the same line as the assignment operator (see examples given)