### PR TITLE
Correct Vim settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1192,7 +1192,7 @@ set shiftwidth=4    " Determine the results of >>, <<, and ==.
 autocmd BufRead,BufNewFile *.jl set filetype=julia
 ```
 
-Then create or edit `.vim/after/ftplugin/julia.vim`, adding the Julia-specifc configuration:
+Then create or edit `.vim/after/syntax/julia.vim`, adding the Julia-specific configuration:
 
 ```
 " ~/.vim/after/ftplugin/julia.vim


### PR DESCRIPTION
The current settings do not work (column highlighting not working). The proposed fix results in the column highlighting for `*.jl` files.

~~The current settings highlight the 93rd column of all files (it always runs). The proposed fix results in the column highlighting only for `*.jl` files.~~